### PR TITLE
[CI] added travis_ci config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: cpp
+sudo: required
+dist: bionic
+compiler:
+  - gcc
+os:
+  - linux
+before_install:
+  - echo $LANG
+  - echo $LC_ALL
+  - sudo apt-get update
+  - sudo apt-get -y install apt-transport-https ca-certificates gnupg software-properties-common wget gpg
+  # https://apt.kitware.com
+  - wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+  - sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
+  - sudo apt-get update
+  - sudo apt-get -y install cmake
+  - sudo apt-get -y install protobuf-compiler protobuf-compiler-grpc
+  - g++ --version
+  - which cmake
+  - cmake --version
+  - /usr/bin/cmake --version
+  - protoc --version
+script:
+  - cd src && /usr/bin/cmake ../src && make

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # cloudstate-cpp-support
+
+[![Build Status](https://travis-ci.com/marcellanz/cloudstate-cpp-support.svg?token=2BznKqtuxx7ufQVAKvxr&branch=master)](https://travis-ci.com/marcellanz/cloudstate-cpp-support)
+
 Cloudstate User Support for C++


### PR DESCRIPTION
Travic CI support:
https://travis-ci.com/github/marcellanz/cloudstate-cpp-support/builds/172285493

@hans-buchmann:
Buildet bei jedem push auf jeden branch. PR zur info. Ob man das statisch builden will ist eine andere Frage; im moment tut es das nach Vorgabe bei [grpc.io](https://grpc.io/docs/languages/cpp/quickstart/) und wir können pushes und PR's validieren.