### PR TITLE
feature/tck docker image

### DIFF
--- a/tck/Dockerfile
+++ b/tck/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:bionic
+
+RUN apt-get update
+RUN apt-get -y install apt-transport-https ca-certificates gnupg software-properties-common wget gpg
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
+RUN apt-get update
+RUN apt-get -y install protobuf-compiler protobuf-compiler-grpc git cmake g++
+RUN g++ --version
+RUN cmake --version
+
+RUN mkdir -p /srv/cloudstate_build/src
+WORKDIR /srv/cloudstate_build/src
+COPY ./src/cloudstate /srv/cloudstate_build/src/cloudstate
+COPY ./src/main.cpp .
+COPY ./src/CMakeLists.txt .
+
+# build it
+RUN cmake ../src && make
+
+FROM ubuntu:bionic
+RUN mkdir -p /srv/cloudstate
+WORKDIR /srv/cloudstate
+COPY --from=0 /srv/cloudstate_build/src/cloudstate-tck .
+EXPOSE 8080
+ENV HOST 0.0.0.0
+ENV PORT 8080
+ENTRYPOINT ["/srv/cloudstate/cloudstate-tck"]

--- a/tck/build_docker_image.sh
+++ b/tck/build_docker_image.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+export DOCKER_BUILDKIT=1
+docker build -t gcr.io/mrcllnz/cloudstate-cpp-tck:latest -f tck/Dockerfile .

--- a/tck/run_dev_proxy_tck.sh
+++ b/tck/run_dev_proxy_tck.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -o nounset
+
+function rnd() {
+  cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1
+}
+
+PROXY_IMAGE=${2:-cloudstateio/cloudstate-proxy-dev-mode:latest}
+PROXY="cloudstate-proxy-$(rnd)"
+TCK_IMAGE=${3:-cloudstateio/cloudstate-tck:latest}
+TCK="cloudstate-tck-$(rnd)"
+
+finally() {
+  docker rm -f "$PROXY"
+}
+trap finally EXIT
+set -x
+
+# run the proxy
+docker run -d --name "$PROXY" -p 9000:9000 -e USER_FUNCTION_HOST=host.docker.internal -e USER_FUNCTION_PORT=8090 "${PROXY_IMAGE}" || exit $?
+# run the tck
+docker run --rm --name cloudstate-tck -p 8090:8090 -e TCK_HOST=0.0.0.0 -e TCK_PROXY_HOST=host.docker.internal -e TCK_FRONTEND_HOST=host.docker.internal "${TCK_IMAGE}"
+tck_status=$?
+
+exit $tck_status

--- a/tck/run_tck.sh
+++ b/tck/run_tck.sh
@@ -17,9 +17,9 @@ trap finally EXIT
 set -x
 
 # run the proxy
-docker run -d --name "$PROXY" -p 9000:9000 -e USER_FUNCTION_HOST=host.docker.internal -e USER_FUNCTION_PORT=8080 "${PROXY_IMAGE}" || exit $?
+docker run -d --name "$PROXY" -p 9000:9000 -e USER_FUNCTION_HOST=host.docker.internal -e USER_FUNCTION_PORT=8090 "${PROXY_IMAGE}" || exit $?
 # run the tck
-docker run --rm --name cloudstate-tck -e TCK_HOST=0.0.0.0 -e TCK_PROXY_HOST=host.docker.internal -e TCK_FRONTEND_HOST=host.docker.internal "${TCK_IMAGE}"
+docker run --rm --name cloudstate-tck -p 8090:8090 -e TCK_HOST=0.0.0.0 -e TCK_PROXY_HOST=host.docker.internal -e TCK_FRONTEND_HOST=host.docker.internal "${TCK_IMAGE}"
 tck_status=$?
 
 exit $tck_status


### PR DESCRIPTION
- fixes #4
- also fixes the `run_dev_proxy_tck.sh` script, which runs the Cloudstate TCK against a process running locally on :8080